### PR TITLE
Fix use a custom github token on changesets

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,6 +19,8 @@ jobs:
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.CHANGESETS_GITHUB_TOKEN }}
 
       - name: Cache Turbo
         uses: actions/cache@v4
@@ -37,7 +39,8 @@ jobs:
       - name: Create Release Pull Request
         uses: changesets/action@v1
         with:
+          commit: "chore: release package(s)"
           publish: bun run release
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.CHANGESETS_GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
This allow changesets to actually create a PR allowed to run CI workflow (which is needed for PR merge)