### PR TITLE
Add support to expansion

### DIFF
--- a/.changeset/nine-bats-melt.md
+++ b/.changeset/nine-bats-melt.md
@@ -1,0 +1,10 @@
+---
+"@diacritic/runtime": patch
+"@diacritic/parser": patch
+"@diacritic/core": patch
+"@diacritic/detector": patch
+"@diacritic/react": patch
+"@diacritic/utilities": patch
+---
+
+Add expansion support for the JSON parser

--- a/examples/vite-react/src/application.tsx
+++ b/examples/vite-react/src/application.tsx
@@ -9,6 +9,7 @@ export function Application() {
 			<p>{t.withHyphen.someKey()}</p>
 			<p>{t.common.interpolation(10)}</p>
 			<p>{t.common.arr().join(" ")}</p>
+			<p>{t.common.expansion()}</p>
 			<button onClick={() => setLanguage(language === "en" ? "pt" : "en")}>
 				{t.common.actions.switch()}
 			</button>

--- a/examples/vite-react/src/locales/en/common.json
+++ b/examples/vite-react/src/locales/en/common.json
@@ -4,5 +4,6 @@
 	},
 	"hello": "Hello World!",
 	"interpolation": "Value {value:number}",
-	"arr": ["some", "string"]
+	"arr": ["some", "string"],
+	"expansion": "Expansion $t.common.hello()"
 }

--- a/examples/vite-react/src/locales/pt/common.json
+++ b/examples/vite-react/src/locales/pt/common.json
@@ -4,5 +4,6 @@
 	},
 	"hello": "Olá mundo!",
 	"interpolation": "Valor {value:number}",
-	"arr": ["alguma", "string"]
+	"arr": ["alguma", "string"],
+	"expansion": "Expansão $t.common.hello()"
 }

--- a/packages/core/src/utilities/generator/types.ts
+++ b/packages/core/src/utilities/generator/types.ts
@@ -24,7 +24,9 @@ function toUnion(arr: string[]) {
 }
 
 function functionFromEntry(entry: Entry) {
-	return `(${entry.args.map(item => item.name + ": " + item.type)}) => ${Array.isArray(entry.return) ? "string[]" : "string"}`;
+	// explicit ignore Proxy argument
+	const args = entry.args.filter(item => item.type !== "Proxy").map(item => item.name + ": " + item.type);
+	return `(${args}) => ${Array.isArray(entry.return) ? "string[]" : "string"}`;
 }
 
 export function generateTypes({

--- a/packages/parser/package.json
+++ b/packages/parser/package.json
@@ -28,6 +28,7 @@
 	"dependencies": {
 		"@diacritic/core": "workspace:",
 		"@diacritic/utilities": "workspace:",
+		"nanoid": "^5.0.7",
 		"tiny-invariant": "^1.3.3"
 	}
 }

--- a/packages/parser/src/utilities/nanoid.ts
+++ b/packages/parser/src/utilities/nanoid.ts
@@ -1,0 +1,3 @@
+import { customAlphabet } from "nanoid";
+
+export const nanoid = customAlphabet("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz", 10);

--- a/packages/parser/test/json.test.ts
+++ b/packages/parser/test/json.test.ts
@@ -11,6 +11,7 @@ const json = JSON.stringify({
 	non: false,
 	stringOrObject: Symbol.for("abuble"),
 	butKeepArrays: [1, false, "string", "another"],
+	expansion: "some $t.deep.expansion({ a : number })",
 });
 
 describe("parseJson", () => {
@@ -26,11 +27,12 @@ describe("parseJson", () => {
 	it("should correctly parse a json content into function entries", () => {
 		const parser = parserJson();
 		expect(parser.convertFile(json)).toStrictEqual([
-			{ name: "hello", path: "hello", args: [], return: "world" },
-			{ name: "someDeepNest", path: "some.deep.nest", args: [], return: "content" },
-			{ name: "someDeepInterpolated", path: "some.deep.interpolated", args: [{ name: "a", type: "number" }], return: "${a}" },
-			{ name: "interpolator", path: "interpolator", args: [{ name: "value", type: "string" }], return: "some ${value}" },
-			{ name: "butKeepArrays", path: "butKeepArrays", args: [], return: ["string", "another"] },
+			{ name: "hello", path: "hello", args: [{ name: expect.any(String), type: "Proxy" }], return: "world" },
+			{ name: "someDeepNest", path: "some.deep.nest", args: [{ name: expect.any(String), type: "Proxy" }], return: "content" },
+			{ name: "someDeepInterpolated", path: "some.deep.interpolated", args: [{ name: expect.any(String), type: "Proxy" }, { name: "a", type: "number" }], return: "${a}" },
+			{ name: "interpolator", path: "interpolator", args: [{ name: expect.any(String), type: "Proxy" }, { name: "value", type: "string" }], return: "some ${value}" },
+			{ name: "butKeepArrays", path: "butKeepArrays", args: [{ name: expect.any(String), type: "Proxy" }], return: ["string", "another"] },
+			{ name: "expansion", path: "expansion", args: [{ name: expect.any(String), type: "Proxy" }, { name: "a", type: "number" }], return: expect.stringContaining("deep.expansion(a)") },
 		]);
 	});
 });

--- a/packages/parser/test/utilities/parser.test.ts
+++ b/packages/parser/test/utilities/parser.test.ts
@@ -1,6 +1,7 @@
+/* eslint-disable no-template-curly-in-string */
 import { describe, expect, it } from "vitest";
 
-import { extractArgumentsFromString, functionName } from "~/utilities/parser";
+import { extractArgumentsFromString, functionName, transformReturnFromString } from "~/utilities/parser";
 
 describe("functionName", () => {
 	it("should correctly create a function name based on keys", () => {
@@ -22,5 +23,24 @@ describe("extractArgumentsFromString", () => {
 				{ name: "string", type: "string" },
 				{ name: "various", type: "number" },
 			]);
+	});
+});
+
+describe("transformReturnFromString", () => {
+	it("should correctly transform return from string", () => {
+		const proxyName = "proxy";
+
+		expect(transformReturnFromString(proxyName, "string with no args")).toBe("string with no args");
+		expect(transformReturnFromString(proxyName, "string with {one: arg}")).toBe("string with ${one}");
+		expect(transformReturnFromString(proxyName, "string with $t.expansion()")).toBe("string with ${proxy.expansion()}");
+		expect(transformReturnFromString(proxyName, "string with $t.expansion({some: arg}, {another: arg})")).toBe("string with ${proxy.expansion(some, another)}");
+		expect(transformReturnFromString(proxyName, "$t.expansion")).toBe("$t.expansion");
+		expect(transformReturnFromString(proxyName, "$t")).toBe("$t");
+		expect(transformReturnFromString(proxyName, "$t()")).toBe("$t()");
+		expect(transformReturnFromString(proxyName, "$t.")).toBe("$t.");
+		expect(transformReturnFromString(proxyName, "$t.expansion({")).toBe("$t.expansion({");
+		expect(transformReturnFromString(proxyName, "$t.expansion({})")).toBe("$t.expansion({})");
+		expect(transformReturnFromString(proxyName, "$t.expansion({name})")).toBe("$t.expansion({name})");
+		expect(transformReturnFromString(proxyName, "$t.expansion({name:})")).toBe("${proxy.expansion()}");
 	});
 });

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -9,7 +9,7 @@ export type Language = Registry["languages"][number];
 export type Namespace = Registry["namespaces"][number];
 
 function createProxy(language: Language,	modules: Record<Language, Record<Namespace, any>>) {
-	return new DeepProxy({}, {
+	const proxy: Proxy = new DeepProxy({}, {
 		get(_, property) {
 			if (typeof property !== "string") return;
 
@@ -32,9 +32,11 @@ function createProxy(language: Language,	modules: Record<Language, Record<Namesp
 			}, "");
 
 			const fn: any = modules[language]![namespace as Namespace][name];
-			return fn(...args);
+			return fn(proxy, ...args);
 		},
 	});
+
+	return proxy;
 }
 
 /**

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -159,6 +159,9 @@ importers:
       '@diacritic/utilities':
         specifier: 'workspace:'
         version: link:../utilities
+      nanoid:
+        specifier: ^5.0.7
+        version: 5.0.7
       tiny-invariant:
         specifier: ^1.3.3
         version: 1.3.3
@@ -2793,6 +2796,11 @@ packages:
   nanoid@3.3.7:
     resolution: {integrity: sha512-eSRppjcPIatRIMC1U6UngP8XFcz8MQWGQdt1MTBQ7NaAmvXDfvNxbvWV3x2y6CdEUciCSsDHDQZbhYaB8QEo2g==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
+    hasBin: true
+
+  nanoid@5.0.7:
+    resolution: {integrity: sha512-oLxFY2gd2IqnjcYyOXD8XGCftpGtZP2AbHbOkthDkvRywH5ayNtPVy9YlOPcHckXzbLTCHpkb7FB+yuxKV13pQ==}
+    engines: {node: ^18 || >=20}
     hasBin: true
 
   natural-compare-lite@1.4.0:
@@ -6895,6 +6903,8 @@ snapshots:
       thenify-all: 1.6.0
 
   nanoid@3.3.7: {}
+
+  nanoid@5.0.7: {}
 
   natural-compare-lite@1.4.0: {}
 


### PR DESCRIPTION
- Now the JSON module and the core module correctly handle support for expansion

The following JSON:
```json
{
  "expansion": "$t.common.hello()"
}
```

Will generate:
```ts
export function expansion(someRandomChar: Proxy) {
  return `${someRandomChar.common.hello()}`
}
```

- To this work correctly, the proxy is passed to itself on fn evaluation