### PR TITLE
Remove create diacritic utility

### DIFF
--- a/documentation/src/guides/index.md
+++ b/documentation/src/guides/index.md
@@ -162,10 +162,11 @@ Now you can use the generated translations in your code, but first you need to c
 ```ts twoslash
 // @filename: index.ts
 // ---cut-before---
-import { createDiacritic } from "@diacritic/runtime";
+import { Diacritic } from "@diacritic/runtime";
 import * as registry from "virtual:translations/registry";
 
-const diacritic = await createDiacritic(registry, "en", ["common"]);
+const diacritic = new Diacritic(registry, "en");
+await diacritic.loadModules(["en"], ["common"]);
 
 console.log(diacritic.t.common.hello());
 console.log(diacritic.t.common.nameAndAge("John", 25));

--- a/documentation/src/integrations/react.md
+++ b/documentation/src/integrations/react.md
@@ -37,7 +37,7 @@ To use the Diacritic React integration, you will need to import the `DiacriticPr
 // ---cut-before---
 import { detect } from "@diacritic/detector";
 import { htmlLangAttributeDetector } from "@diacritic/detector/client";
-import { DiacriticProvider, createDiacritic, useTranslation } from "@diacritic/react";
+import { Diacritic, DiacriticProvider, useTranslation } from "@diacritic/react";
 import { createRoot } from "react-dom/client";
 import * as registry from "virtual:translations/registry";
 
@@ -49,7 +49,9 @@ function Component() {
 
 async function main() {
 	const language = detect(registry, htmlLangAttributeDetector);
-	const diacritic = await createDiacritic(registry, language, ["common"]);
+	const diacritic = new Diacritic(registry, language);
+
+	await diacritic.loadModules([language], ["common"]);
 
 	createRoot(document.getElementById("root")!).render(
 		<DiacriticProvider diacritic={diacritic}>

--- a/examples/vite-react/src/main.tsx
+++ b/examples/vite-react/src/main.tsx
@@ -1,6 +1,6 @@
 import { detect } from "@diacritic/detector";
 import { htmlLangAttributeDetector } from "@diacritic/detector/client";
-import { DiacriticProvider, createDiacritic } from "@diacritic/react";
+import { Diacritic, DiacriticProvider } from "@diacritic/react";
 import { StrictMode, Suspense } from "react";
 import { createRoot } from "react-dom/client";
 import * as registry from "virtual:translations/registry";
@@ -9,7 +9,9 @@ import { Application } from "./application";
 
 async function main() {
 	const language = detect(registry, htmlLangAttributeDetector);
-	const diacritic = await createDiacritic(registry, language, ["common"]);
+	const diacritic = new Diacritic(registry, language);
+
+	await diacritic.loadModules([language], ["common"]);
 
 	createRoot(document.getElementById("root")!).render(
 		<DiacriticProvider diacritic={diacritic}>

--- a/packages/react/src/index.tsx
+++ b/packages/react/src/index.tsx
@@ -82,5 +82,5 @@ export function useTranslation<const N extends Namespace>(namespaces: N[]): UseT
 	return context;
 }
 
-export { createDiacritic } from "@diacritic/runtime";
-export type { Diacritic, Language, Namespace, Proxy } from "@diacritic/runtime";
+export { Diacritic } from "@diacritic/runtime";
+export type { Language, Namespace, Proxy } from "@diacritic/runtime";

--- a/packages/react/test/index.test.tsx
+++ b/packages/react/test/index.test.tsx
@@ -2,7 +2,7 @@ import { render, renderHook } from "@testing-library/react";
 import { useContext } from "react";
 import { describe, expect, it, vi } from "vitest";
 
-import { DiacriticContext, DiacriticProvider, createDiacritic, useTranslation } from "~/index";
+import { Diacritic, DiacriticContext, DiacriticProvider, useTranslation } from "~/index";
 
 const importTranslationModule = vi.fn().mockResolvedValue({});
 
@@ -15,7 +15,8 @@ const registry = {
 
 describe("<DiacriticProvider/>", () => {
 	it("should render correctly", async () => {
-		const instance = await createDiacritic(registry, "en", ["common"]);
+		const instance = new Diacritic(registry, "en");
+		await instance.loadModules(["en"], ["common"]);
 
 		const { getByText } = render(
 			<DiacriticProvider diacritic={instance}>
@@ -27,7 +28,8 @@ describe("<DiacriticProvider/>", () => {
 	});
 
 	it("should provide diacritic instance correctly", async () => {
-		const instance = await createDiacritic(registry, "en", ["common"]);
+		const instance = new Diacritic(registry, "en");
+		await instance.loadModules(["en"], ["common"]);
 
 		function useDiacriticContext() {
 			return useContext(DiacriticContext);
@@ -47,7 +49,8 @@ describe("<DiacriticProvider/>", () => {
 
 describe("useTranslation()", () => {
 	it("should return the diacritic instance", async () => {
-		const instance = await createDiacritic(registry, "en", ["common"]);
+		const instance = new Diacritic(registry, "en");
+		await instance.loadModules(["en"], ["common"]);
 
 		const { result } = renderHook(() => useTranslation(["common"]), {
 			wrapper: ({ children }) => (
@@ -61,7 +64,8 @@ describe("useTranslation()", () => {
 	});
 
 	it("should rerender on language change", async () => {
-		const instance = await createDiacritic(registry, "en", ["common"]);
+		const instance = new Diacritic(registry, "en");
+		await instance.loadModules(["en"], ["common"]);
 
 		const { result } = renderHook(() => useTranslation(["common"]), {
 			wrapper: ({ children }) => (

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -54,7 +54,7 @@ function createProxy(language: Language,	modules: Record<Language, Record<Namesp
  * const diacritic = await createDiacritic("en", ["common"]);
  * ```
  */
-class Diacritic {
+export class Diacritic {
 	public readonly registry!: Registry;
 	public readonly languages!: Language[];
 	public readonly namespaces!: Namespace[];
@@ -122,28 +122,4 @@ class Diacritic {
 	}
 }
 
-/**
- * This function is used to create a new instance of the Diacritic class.
- *
- * @example
- * ```ts
- * import * as registry from "virtual:translations/registry";
- *
- * const language = detect(htmlLangAttributeDetector); // Use the detector to get the initial language
- * const diacritic = await createDiacritic(registry, language, ["common"]);
- * ```
- *
- * @param registry the registry object (import from virtual module "virtual:translations/registry")
- * @param language the initial language
- * @param initialNamespaces the initial namespaces to load
- * @returns a new instance of the Diacritic class
- */
-export async function createDiacritic(registry: Registry, language: Language,	initialNamespaces: Namespace[]) {
-	const diacritic = new Diacritic(registry, language);
-	await diacritic.loadModules([language], initialNamespaces);
-
-	return diacritic;
-}
-
-export type { Diacritic };
 export type { Proxy };

--- a/packages/runtime/test/index.test.ts
+++ b/packages/runtime/test/index.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, expect, it, vi } from "vitest";
 
-import { createDiacritic } from "~/index";
+import { Diacritic } from "~/index";
 
 const importTranslationModule = vi.fn();
 
@@ -16,7 +16,8 @@ afterEach(() => {
 });
 
 it("should create a diacritic runtime correctly", async () => {
-	const runtime = await createDiacritic(registry, "en", ["common"]);
+	const runtime = new Diacritic(registry, "en");
+	await runtime.loadModules(["en"], ["common"]);
 
 	expect(runtime).not.toBeUndefined();
 	expect(runtime.language).toBe("en");
@@ -24,7 +25,8 @@ it("should create a diacritic runtime correctly", async () => {
 });
 
 it("should change language correctly", async () => {
-	const runtime = await createDiacritic(registry, "en", ["common"]);
+	const runtime = new Diacritic(registry, "en");
+	await runtime.loadModules(["en"], ["common"]);
 
 	expect(runtime.language).toBe("en");
 	runtime.setLanguage("pt");
@@ -32,7 +34,9 @@ it("should change language correctly", async () => {
 });
 
 it("should listen to language change correctly", async () => {
-	const runtime = await createDiacritic(registry, "en", ["common"]);
+	const runtime = new Diacritic(registry, "en");
+	await runtime.loadModules(["en"], ["common"]);
+
 	const onChange = vi.fn();
 
 	const dispose = runtime.onChange(onChange);
@@ -49,7 +53,8 @@ it("should listen to language change correctly", async () => {
 it("should load new modules correctly", async () => {
 	importTranslationModule.mockResolvedValue({});
 
-	const runtime = await createDiacritic(registry, "en", ["common"]);
+	const runtime = new Diacritic(registry, "en");
+	await runtime.loadModules(["en"], ["common"]);
 
 	expect(runtime.needToLoadModules(["pt"], ["common"])).toBe(true);
 	expect(runtime.needToLoadModules(["en"], ["common"])).toBe(false);
@@ -66,7 +71,8 @@ it("should call translation functions correctly", async () => {
 		hello: () => "world",
 	});
 
-	const runtime = await createDiacritic(registry, "en", ["common"]);
+	const runtime = new Diacritic(registry, "en");
+	await runtime.loadModules(["en"], ["common"]);
 
 	expect((runtime.t as any).another).toThrow("Namespace another is not loaded");
 	expect((runtime.t as any).common.nonExistent).toThrow("Function nonExistent is not defined in namespace common");


### PR DESCRIPTION
- When using in react native context, it's better to split sync and async logic to manually control splash screen, so I've removed the createDiacritic utility and re-export the class 